### PR TITLE
Fix Task ambiguity compilation error in JWT event handlers

### DIFF
--- a/B2BBackend/Program.cs
+++ b/B2BBackend/Program.cs
@@ -59,7 +59,7 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
             OnAuthenticationFailed = context =>
             {
                 Console.WriteLine($"[DEBUG] JWT Authentication Failed: {context.Exception?.Message}");
-                return Task.CompletedTask;
+                return System.Threading.Tasks.Task.CompletedTask;
             },
             OnTokenValidated = context =>
             {
@@ -68,12 +68,12 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
                 {
                     Console.WriteLine($"[DEBUG] Validated Claim: {claim.Type} = {claim.Value}");
                 }
-                return Task.CompletedTask;
+                return System.Threading.Tasks.Task.CompletedTask;
             },
             OnChallenge = context =>
             {
                 Console.WriteLine($"[DEBUG] JWT Challenge: {context.Error}, {context.ErrorDescription}");
-                return Task.CompletedTask;
+                return System.Threading.Tasks.Task.CompletedTask;
             }
         };
     });


### PR DESCRIPTION
🐛 COMPILATION ERROR:
CS0104: 'Task' is an ambiguous reference between 'B2BBackend.Models.Task' and 'System.Threading.Tasks.Task'

🔧 SOLUTION:
- Explicitly qualify Task references in JWT event handlers as System.Threading.Tasks.Task
- Changed Task.CompletedTask to System.Threading.Tasks.Task.CompletedTask
- Resolves naming conflict between model class and threading class

✅ RESULT:
- Backend should now compile successfully
- JWT authentication debugging still intact
- All Task references properly qualified